### PR TITLE
[Refactor] Swift 6 strict concurrency adaptations

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,14 +1,6 @@
 {
+  "originHash" : "557939a2717d7a64b986c70299fe6bf4476150b358186cfcdb9d1a31c28a4303",
   "pins" : [
-    {
-      "identity" : "apollo-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apollographql/apollo-ios.git",
-      "state" : {
-        "revision" : "759a665fba28b5a2e4fa51897158f9817b99bc03",
-        "version" : "1.2.1"
-      }
-    },
     {
       "identity" : "appauth-ios",
       "kind" : "remoteSourceControl",
@@ -16,42 +8,6 @@
       "state" : {
         "revision" : "2781038865a80e2c425a1da12cc1327bcd56501f",
         "version" : "1.7.6"
-      }
-    },
-    {
-      "identity" : "inflectorkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattt/InflectorKit",
-      "state" : {
-        "revision" : "d8cbcc04972690aaa5fc760a2b9ddb3e9f0decd7",
-        "version" : "1.0.0"
-      }
-    },
-    {
-      "identity" : "sqlite.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/stephencelis/SQLite.swift.git",
-      "state" : {
-        "revision" : "7a2e3cd27de56f6d396e84f63beefd0267b55ccb",
-        "version" : "0.14.1"
-      }
-    },
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
-      "state" : {
-        "revision" : "fee6933f37fde9a5e12a1e4aeaa93fe60116ff2a",
-        "version" : "1.2.2"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections",
-      "state" : {
-        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
-        "version" : "1.0.4"
       }
     },
     {
@@ -73,5 +29,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/trifork/TIM-iOS", from: "2.9.3"),
-        .package(url: "https://github.com/apollographql/apollo-ios.git", from: "1.0.5")
+        .package(url: "https://github.com/trifork/TIM-iOS", from: "2.9.3")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -23,15 +22,8 @@ let package = Package(
         .target(
             name: "TriforkHealthPlatformSDK",
             dependencies: [
-                .product(name: "TIM", package: "TIM-iOS"),
-                .product(name: "Apollo", package: "apollo-ios")
+                .product(name: "TIM", package: "TIM-iOS")
             ]
-        ),
-        .testTarget(
-            name: "TriforkHealthPlatformSDKTests",
-            dependencies: [
-                "TriforkHealthPlatformSDK"
-            ]
-        ),
+        )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -1,2 +1,366 @@
-# thp-ios-sdk
-Trifork Health Platform iOS SDK
+# Trifork Health Platform iOS SDK
+
+Trifork Health Platform iOS SDK is a Swift library wrapping [Trifork's Identity Manager iOS SDK](https://github.com/trifork/TIM-iOS) for its usages in THP projects.
+
+## Requirements
+
+| Version | Requirements            |
+|:--------|:------------------------|
+| 1.0.0   | Swift 6.2+<br>iOS 15.0+ |
+
+## Installation
+
+### Swift Package Manager
+
+To install using Swift Package Manager, add this to the `dependencies` section in your `Package.swift` file:
+
+```swift
+.package(url: "https://github.com/trifork/thp-ios-sdk", .upToNextMajor(from: "1.0.0")),
+```
+
+Alternatively, use Xcode's Package Dependency UI to add this library with the following URL: `https://github.com/trifork/thp-ios-sdk`
+
+## Usage
+
+### Main entry point
+
+The library has two main entry points, depending on how the client app is setup. The first, and easiest, is using the singleton instance as such:
+
+```swift
+import TriforkHealthPlatformSDK
+
+let thp = THP.shared
+```
+Bear in mind that this instance **is not configured from the start**. As such, you'll need to call the `configure(_:)` function, as explained below.
+
+If your app uses a Dependency Injection system that retains specific instances for a given type, you can otherwise use the default _asynchronous_ initializer to obtain an instance:
+
+```swift
+import TriforkHealthPlatformSDK
+
+let config = THPConfiguration(
+    scopes: [ "<scope 1>", "<scope 2>", ... ],
+    realm: "<realm>",
+    clientId: "<clientId>",
+    redirectUrl: URL(string:"<urlScheme>:/")!,
+    baseAuthURL: URL(string: "<Base Auth URL>")!,
+    loginFlowKey: "<Client Login Flow Key>"
+)
+
+let thp = await THP(configuration: config)
+```
+Contrary to the singleton instance, this will return a fully configured THP instance.
+
+In either case, whether the library is fully configured can be checked using the `isConfigured` variable.
+
+For the purposes of this documentation, we will provide code examples using the **singleton** approach.
+
+### Setup configuration
+
+Before using any function or property from `THP` you have to configure the framework by calling the `configure(_:)` function (typically you want to do this on app startup):
+
+```swift
+import TriforkHealthPlatformSDK
+
+let config = THPConfiguration(
+    scopes: [ "<scope 1>", "<scope 2>", ... ],
+    realm: "<realm>",
+    clientId: "<clientId>",
+    redirectUrl: URL(string:"<urlScheme>:/")!,
+    baseAuthURL: URL(string: "<Base Auth URL>")!,
+    loginFlowKey: "<Client Login Flow Key>"
+)
+
+await THP.shared.configure(config)
+```
+
+In case the client app can be setup for different environments (for instance, having different `baseAuthURL`), and the current environment can be selected at runtime, this function can be called multiple times with different configurations. Only the latest configuration provided will be stored, and all internal properties will be reinitilized. This **will not** clear user stored data or logout the current user automatically, so bear in mind that you might need to do so manually depending on your workflow.
+
+Accessing either `auth` or `userStorage` from the main entry point when the library is not fully configured will trigger a `fatalError`. As such, in case you are not sure if the instance if fully configured, check the `isConfigured` property as follows:
+
+```swift
+if THP.shared.isConfigured {
+    // Do stuff requiring access to auth or userStorage
+} else {
+    // Fallback code
+}
+```
+Take into account that the `THP` instance **is not observable**, and as a consequence neither is the `isConfigured` variable. Therefore, you'll need to manually check the property value.
+
+### URL scheme
+
+Setup your URL scheme or Universal Links to receive login redirects, following the [Apple official documentation](https://developer.apple.com/documentation/xcode/allowing_apps_and_websites_to_link_to_your_content/defining_a_custom_url_scheme_for_your_app).
+
+Depending on your life cycle handling, you should handle URL requests in one of the following callbacks:
+
+* SwiftUI: `.onOpenURL(perform:)`
+* SceneDelegate: `scene(_:, openURLContexts:)`
+* AppDelegate: `application(_:, open:, options:) -> Bool`
+
+Example for `SceneDelegate`:
+```swift
+func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    for url: URL in URLContexts.map({ $0.url }) {
+        THP.shared.auth.handleRedirect(url: url)
+    }
+}
+```
+
+### FaceID permission in `Info.plist`
+
+As per [Apple's documentation](https://developer.apple.com/documentation/bundleresources/information_property_list/nsfaceidusagedescription), remember to set the value for the `NSFaceIDUsageDescription` key in your `Info.plist`  if you intend on using the biometric feature of `THP`, either in the file directly or in the section in the project Build Settings.
+
+## Common use cases
+
+### Register / OIDC Login
+
+All users will have to register through an OpenID Connect login. This is achieved as follows:
+
+```swift
+let flow: THPAuthenticationFlow = .signup // .signin for login 
+
+do {
+    let userId = try await THP.shared.auth.performOpenIDConnectFlow(flow: flow)
+    print("Successfully logged in, with userId \(userId)")
+} catch {
+    print("Failed to perform OpenID Connect login: \(error.localizedDescription)")
+}
+```
+
+### Setting password
+
+To avoid the OpenID Connect login everytime the user needs a valid session, you can provide a password, which will allow you to save an encrypted version of the refresh token, such that the user only needs to provide the password to get a valid access token. 
+
+The user must have performed a successful OpenID Connect login before setting a password, since the refresh token has to be available.
+
+```swift
+guard let refreshToken = await THP.shared.auth.refreshToken else {
+    return
+}
+
+do {
+    try await THP.shared.userStorage.storeRefreshToken(refreshToken, withNewPassword: password)
+    print("Saved refresh token")
+} catch {
+    print("Failed to store refresh token: \(error.localizedDescription)")
+}
+```
+
+### Enable biometric login
+
+After the user has created a password, you can enable biometric access for the login. You will need the user's password to do this.
+
+```swift
+do {
+    try await THP.shared.userStorage.enableBiometricAccessForRefreshToken(password: password)
+    print("Successfully enabled biometric login for user.")
+} catch {
+    print("Whoops, something went wrong: \(error.localizedDescription)")
+}
+```
+
+### Login with password/biometrics
+
+The user can use biometrics if it was enabled previously, otherwise you will have to provide the password.
+
+You can set the value of `storeNewRefreshToken` in `loginWithPassword(password:storeNewRefreshToken)` to control whether the system should update the refresh token on successful login. It is **highly recommended** to store the new refresh token, since it will keep renewing the user's session everytime they login. Although, you can set this to `false` for use cases where you don't want to update it. 
+
+```swift
+// Login with password
+do {
+    let newToken = try await THP.shared.auth.loginWithPassword(password: password, storeNewRefreshToken: true)
+    print("Successfully logged in with password.")
+} catch {
+    print("Failed to log in with password.")
+    handleError(error)
+}
+
+// Login with biometrics
+do {
+    let newToken = try await THP.shared.auth.loginWithBiometricId(storeNewRefreshToken: true)
+    print("Successfully logged in with biometrics.")
+} catch {
+    print("Failed to log in with biometrics.")
+    handleError(error)
+}
+
+// Error handling
+func handleError(_ error: THPError) {
+    switch error {
+    case .storage(let storageError):
+        switch storageError {
+        case .incompleteUserDataSet:
+            // Reset user! We cannot recover from this state!
+            break
+        case .encryptedStorageFailed:
+            // Note that this is a simplified error handling, which uses the Bool extensions to avoid huge switch statements.
+            // If you want to handle errors the right way, you should look into all error cases and decide which you need specific
+            // error handling for. The ones you see here are the most common ones, which are very likely to happen.
+            if storageError.isWrongPassword() {
+                // Handle wrong password
+            } else if storageError.isKeyLocked() {
+                // Handle key locked (three wrong password logins)
+            } else if storageError.isBiometricFailedError() {
+                // Bio failed or was cancelled, do nothing.
+            } else if storageError.isKeyServiceError() {
+                // Something went wrong while communicating with the key service (possible network failure)
+            } else {
+                // Something failed - please try again.
+            }
+        }
+    case .auth(let authError):
+        if case THPAuthError.refreshTokenExpired = authError {
+            // Refresh Token has expired.
+        }
+    }
+}
+```
+
+### Make use of the data and the session
+
+#### THPJWT data
+
+The tokens are of the type `THPJWT`, a `Sendable` struct storing the original `String` instance returned by the auth service and some its decoded values in convenient stored properties. Already implemented decoded properties are the following:
+
+* **UserId:** `token.userId` (`String`)
+* **Expiration date:** `token.expireDate` (`Date?`)
+* **Issuer:** `token.issuer` (`String?`)
+* **Login provider**: `token.loginProvider` (`String`)
+
+Note that all of the above except the `userId` return an `Optional` value. Indeed, the token cannot initialize without a valid `userId`, which corresponds to the key `sub`.
+
+In addition, `THPJWT` includes a public `subscript` function:
+```swift
+subscript<Value>(_ key: String) -> Value?
+```
+This function allows a client app to access further information stored in the raw `String` token which might not me accessible through the already implemented properties. As an example:
+```swift
+let loginProvider = token["login_provider"]
+```
+will return the same value stored in `loginProvider`. Bear in mind that every invocation to this function does trigger decoding the raw `String` token.
+
+#### Users
+
+Contrary to TIM, this framework keeps track of a single user that has created passwords and stored encrypted refresh tokens. As such, multiple users cannot use the same device: they need to logout the current user and login or register a new user after that.
+
+#### Refresh token
+
+In most cases you won't have to worry about your refresh token, since `THP` handles this for you. If you should be in a situation where you need it, it can be accessed from the `userStorage`:
+
+```swift
+do {
+    let refreshToken = try await THP.shared.userStorage.getStoredRefreshToken(for: userId, with: password)
+} catch {
+    print("Error retrieving refresh token")
+}
+```
+
+#### Access token
+
+`THP` makes sure that your access token is always valid and refreshed automatically. This is the main reason behind the function `getAccessToken(forceRefresh:)` defined in `THPAuth` being asynchronous.
+
+Most of the time `THP` will complete the call immediately when the token is available, and a bit slower when the token needs to be updated.
+
+You should avoid assigning the value of the access token to a property, and instead always use this function when you need it to make sure the token is valid.
+
+```swift
+do {
+    let accessToken = try await THP.shared.auth.getAccessToken(forceRefresh: false)
+    // Do stuff with the access token here
+} catch {
+    print("Error retrieving access token")
+}
+```
+
+`THP` will refresh the token automatically if it's expired when calling the above function. Nevertheless, you might need an access token that is not just valid, but also has a fresh expiration date. If that is the case, you can force the token to refresh by passing `true` to the function `forceRefresh` parameter as follows:
+
+```swift
+do {
+    let accessToken = try await THP.shared.auth.getAccessToken(forceRefresh: true)
+    // Do stuff with the refreshed access token here
+} catch {
+    print("Error retrieving access token")
+}
+```
+
+### Log out and optionally delete user
+
+You can log out a user by calling the following function:
+```swift
+await THP.shared.auth.logout(clearUser: false)
+```
+
+Optionally you can clear all stored data for that user. When this last option is enabled, `THP` will throw away the current access token and refresh token, such that you will have to load it again by logging in:
+```swift
+await THP.shared.auth.logout(clearUser: true)
+```
+
+### Understanding the errors
+
+`THP` can throw a large set of errors, because of the different dependencies. All errors are wrapped within the `THPError` `enum`, with specific cases `auth` and `storage`, depending on the area that throws the error. The errors will contain other errors coming from the heart of the framework and there are a couple of levels in this:
+
+```swift
+enum THPError: Error {
+    case auth(THPAuthError)
+    case storage(THPStorageError)
+}
+```
+
+Most errors are present to help the debugging process, to make it easy to spot a wrong configuration. Once everything is configured correctly there is a small set of errors to present to the user, most of them coming from `TIM`:
+
+```swift
+// Refresh token has expired
+THPError.auth(THPAuthError.refreshTokenExpired)
+
+// The user pressed cancel in the safari view controller during the OpenID Connect login
+THPError.auth(THPAuthError.safariViewControllerCancelled)
+
+THPError.storage(
+    THPStorageError.encryptedStorageFailed(
+        TIMEncryptedStorageError.keyServiceFailed(TIMKeyServiceError.badPassword)
+    )
+) 
+
+THPError.storage(
+    THPStorageError.encryptedStorageFailed(
+        TIMEncryptedStorageError.keyServiceFailed(TIMKeyServiceError.keyLocked)
+    )
+) 
+```
+
+Since the `TIMKeyServiceError`s are so deeply into the error structure, there are short hands for this on the `THPStorageError` type:
+
+```swift
+if storageError.isKeyLocked() {
+    // Handle key locked (happens on wrong password three times in a row)
+}
+if storageError.isWrongPassword() {
+    // Handle wrong password
+}
+if storageError.isKeyServiceError() {
+    // The communication with the KeyService failed. E.g. no internet connection.
+}
+if storageError.isBiometricFailedError() {
+    // Handle biometric failed/was cancelled scenario.
+}
+```
+
+Other errors should of course still be handled, but they can be handled in a more generic way since they might be caused by network issues, server updates, or other unpredictable cases.
+
+## Architecture
+
+`THP` depends on `TIM`, which in turn depends on `AppAuth` and `TIMEncryptedStorage`. In essence, `THP` wraps `TIM` usage for common use cases (see sections above), such that signing in/up and encrypted storage are easy to manage.
+
+## Breaking changes from `0.x`
+
+There have been significant breaking changes in version `1.x`, mainly due to the adoption of Swift 6.2 and compliance with strict concurrency. Specifically:
+
+* iOS minimum version has been increased to 15 or higher to enable usage of `async/await` syntax.
+* Swift minimum version has been increased to 6.2 to take full advantage of new features and strict concurrency. Note that this might restrict the Xcode version used when integrating this library into a project.
+* All functions returning `AnyPublisher<Value, Error>` have been converted to `async throws` functions returning `Value` and throwing the same `Error` type as the one wrapped in the `Publisher`, although the error is not safely typed within the `throws` signature due to language restrictions and `THPError` being a wrapper of `TIMError`.
+* `THPAuth`, `THPUserStorage` and `TIMManager` (and their implementations) have been converted from `class` to `actor`, and all properties and functions are isolated and marked as `async`.
+* `THPAuthenticationFlow`, `THPConfiguration` and `THPJWT` are now conforming to `Sendable`.
+* Implementation of `THPJWT` has been expanded to include new properties, and a new subscript function to access custom key-value pairs in the token.
+* `THP` function `configure(configuration:customOIDExternalUserAgent:)` has been changed to `configure(_ configuration:)` for simplicity.
+
+In addition, [Apollo iOS](https://github.com/apollographql/apollo-ios) has been removed as a dependency from this library, as it was not used anywhere. Furthermore, it should be the client app's responsibility, and not this library's, to integrate with whichever networking SDK they need to. This library **should not** enforce any pattern beyond what is strictly required to authenticate with `TIM`. Otherwise, it becomes part of a specific client app and not a reusable framework.

--- a/Sources/TriforkHealthPlatformSDK/Core/Extensions/Locale+ApplicationLocale.swift
+++ b/Sources/TriforkHealthPlatformSDK/Core/Extensions/Locale+ApplicationLocale.swift
@@ -1,10 +1,3 @@
-//
-//  File.swift
-//  
-//
-//  Created by Nicolai Harbo on 15/06/2023.
-//
-
 import Foundation
 
 extension Locale {

--- a/Sources/TriforkHealthPlatformSDK/Core/Extensions/Notification.Name+Extension.swift
+++ b/Sources/TriforkHealthPlatformSDK/Core/Extensions/Notification.Name+Extension.swift
@@ -1,10 +1,3 @@
-//
-//  Notification.Name+Extension.swift
-//  
-//
-//  Created by Nicolai Harbo on 28/08/2023.
-//
-
 import Foundation
 
 public extension Notification.Name {

--- a/Sources/TriforkHealthPlatformSDK/Core/Extensions/THPJWT+values.swift
+++ b/Sources/TriforkHealthPlatformSDK/Core/Extensions/THPJWT+values.swift
@@ -1,27 +1,35 @@
 import Foundation
 
-private let EXPIRE_KEY: String = "exp"
-private let SUB_KEY: String = "sub"
-private let ISSUER_KEY: String = "iss"
-
 /// Type alias for tokens - just a string.
 public typealias THPJWTString = String
 
-/// Extensions for default data on a JWT.
-extension THPJWTString {
+public typealias THPJWTDecoded = [String: Any]
 
+extension THPJWTDecoded {
+    private enum Key {
+        static let expireDate: String = "exp"
+        static let userId: String = "sub"
+        static let issuer: String = "iss"
+        static let loginProvider: String = "login_provider"
+    }
+    
     /// `exp` value
     var expireTimestamp: TimeInterval? {
-        THPJWTDecoder.decode(jwtToken: self)[EXPIRE_KEY] as? TimeInterval
+        self[THPJWTDecoded.Key.expireDate] as? TimeInterval
     }
 
     /// `sub` value
     var userId: String? {
-        THPJWTDecoder.decode(jwtToken: self)[SUB_KEY] as? String
+        self[THPJWTDecoded.Key.userId] as? String
     }
 
     /// `iss` value
     var issuer: String? {
-        THPJWTDecoder.decode(jwtToken: self)[ISSUER_KEY] as? String
+        self[THPJWTDecoded.Key.issuer] as? String
+    }
+
+    /// `login_provider` value
+    var loginProvider: String? {
+        self[THPJWTDecoded.Key.loginProvider] as? String
     }
 }

--- a/Sources/TriforkHealthPlatformSDK/Core/Extensions/THPJWT+values.swift
+++ b/Sources/TriforkHealthPlatformSDK/Core/Extensions/THPJWT+values.swift
@@ -1,10 +1,3 @@
-//
-//  File.swift
-//
-//
-//  Created by Nicolai Harbo on 20/06/2023.
-//
-
 import Foundation
 
 private let EXPIRE_KEY: String = "exp"

--- a/Sources/TriforkHealthPlatformSDK/Core/Extensions/TIMDataStorage+ClearAllUsers.swift
+++ b/Sources/TriforkHealthPlatformSDK/Core/Extensions/TIMDataStorage+ClearAllUsers.swift
@@ -1,10 +1,3 @@
-//
-//  File.swift
-//  
-//
-//  Created by Nicolai Harbo on 15/06/2023.
-//
-
 import Foundation
 import TIM
 

--- a/Sources/TriforkHealthPlatformSDK/Core/Helpers/THPJWTDecoder.swift
+++ b/Sources/TriforkHealthPlatformSDK/Core/Helpers/THPJWTDecoder.swift
@@ -1,10 +1,3 @@
-//
-//  THPJWTDecoder.swift
-//
-//
-//  Created by Nicolai Harbo on 20/06/2023.
-//
-
 import Foundation
 
 final class THPJWTDecoder {

--- a/Sources/TriforkHealthPlatformSDK/Core/Helpers/THPJWTDecoder.swift
+++ b/Sources/TriforkHealthPlatformSDK/Core/Helpers/THPJWTDecoder.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-final class THPJWTDecoder {
-    static func decode(jwtToken jwt: String) -> [String: Any] {
+enum THPJWTDecoder {
+    static func decode(jwtToken jwt: THPJWTString) -> THPJWTDecoded {
         let segments = jwt.components(separatedBy: ".")
         return segments.count > 2 ? decodeJWTPart(segments[1]) : [:]
     }
@@ -11,7 +11,7 @@ final class THPJWTDecoder {
             .replacingOccurrences(of: "-", with: "+")
             .replacingOccurrences(of: "_", with: "/")
 
-        let length = Double(base64.lengthOfBytes(using: String.Encoding.utf8))
+        let length = Double(base64.lengthOfBytes(using: .utf8))
         let requiredLength = 4 * ceil(length / 4.0)
         let paddingLength = requiredLength - length
         if paddingLength > 0 {
@@ -21,9 +21,11 @@ final class THPJWTDecoder {
         return Data(base64Encoded: base64, options: .ignoreUnknownCharacters)
     }
 
-    private static func decodeJWTPart(_ value: String) -> [String: Any] {
+    private static func decodeJWTPart(_ value: String) -> THPJWTDecoded {
         guard let bodyData = base64UrlDecode(value),
-              let json = try? JSONSerialization.jsonObject(with: bodyData, options: []), let payload = json as? [String: Any] else {
+              let json = try? JSONSerialization.jsonObject(with: bodyData, options: []),
+              let payload = json as? THPJWTDecoded
+        else {
             return [:]
         }
 

--- a/Sources/TriforkHealthPlatformSDK/Core/Misc/CustomOIDExternalUserAgent.swift
+++ b/Sources/TriforkHealthPlatformSDK/Core/Misc/CustomOIDExternalUserAgent.swift
@@ -2,11 +2,6 @@ import AppAuth
 import WebKit
 
 public class THPOIDExternalUserAgent: OIDExternalUserAgentIOS {
-    
-    public init?() {
-        super.init(presenting: UIViewController())
-    }
-    
     public override func present(_ request: OIDExternalUserAgentRequest, session: OIDExternalUserAgentSession) -> Bool {
         guard let url = request.externalUserAgentRequestURL() else {
             return false

--- a/Sources/TriforkHealthPlatformSDK/Core/Misc/CustomOIDExternalUserAgent.swift
+++ b/Sources/TriforkHealthPlatformSDK/Core/Misc/CustomOIDExternalUserAgent.swift
@@ -1,10 +1,3 @@
-//
-//  CustomOIDExternalUserAgent.swift
-//  
-//
-//  Created by Nicolai Harbo on 28/08/2023.
-//
-
 import AppAuth
 import WebKit
 

--- a/Sources/TriforkHealthPlatformSDK/Data/Models/THPAuthenticationFlow.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Models/THPAuthenticationFlow.swift
@@ -1,4 +1,4 @@
-public enum THPAuthenticationFlow: String {
+public enum THPAuthenticationFlow: String, Sendable {
     case signup
     case signin
 }

--- a/Sources/TriforkHealthPlatformSDK/Data/Models/THPAuthenticationFlow.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Models/THPAuthenticationFlow.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public enum THPAuthenticationFlow: String {
     case signup
     case signin

--- a/Sources/TriforkHealthPlatformSDK/Data/Models/THPAuthenticationFlow.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Models/THPAuthenticationFlow.swift
@@ -1,10 +1,3 @@
-//
-//  THPAuthenticationFlow.swift
-//  
-//
-//  Created by Nicolai Harbo on 15/06/2023.
-//
-
 import Foundation
 
 public enum THPAuthenticationFlow: String {

--- a/Sources/TriforkHealthPlatformSDK/Data/Models/THPConfiguration.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Models/THPConfiguration.swift
@@ -9,6 +9,14 @@ public struct THPConfiguration: Sendable {
     public let redirectUrl: String
     public let loginFlowKey: String
     
+    /// Default constructor
+    /// - Parameters:
+    ///   - scopes: Scopes, e.g. `["scope"]`
+    ///   - realm: Realm, e.g. `"my-test-realm"`
+    ///   - clientId: Client Id, e.g. `"my-client"`
+    ///   - redirectUrl: Redirect URL, e.g. `"my-app:/"`
+    ///   - baseAuthURL: Base base URL to authenticate, e.g. https://trifork.com
+    ///   - loginFlowKey: The client app key to identify the login flow source, e.g. `"client-flow"`
     public init(
         scopes: [String],
         realm: String,

--- a/Sources/TriforkHealthPlatformSDK/Data/Models/THPConfiguration.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Models/THPConfiguration.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TIM
 
-public struct THPConfiguration {
+public struct THPConfiguration: Sendable {
     public let baseAuthURL: URL
     public let scopes: [String]
     public let realm: String

--- a/Sources/TriforkHealthPlatformSDK/Data/Models/THPConfiguration.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Models/THPConfiguration.swift
@@ -1,10 +1,3 @@
-//
-//  File.swift
-//  
-//
-//  Created by Nicolai Harbo on 15/06/2023.
-//
-
 import Foundation
 import TIM
 

--- a/Sources/TriforkHealthPlatformSDK/Data/Models/THPError.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Models/THPError.swift
@@ -1,10 +1,3 @@
-//
-//  File.swift
-//  
-//
-//  Created by Nicolai Harbo on 20/06/2023.
-//
-
 import Foundation
 import TIM
 import TIMEncryptedStorage
@@ -17,9 +10,9 @@ extension TIMError {
     func asTHPError() -> THPError {
         switch self {
         case .auth(let error):
-            return .auth(error)
+            .auth(error)
         case .storage(let error):
-            return .storage(error)
+            .storage(error)
         }
     }
 }
@@ -31,9 +24,9 @@ public enum THPError: Error {
     public var errorDescription: String? {
         switch self {
         case .auth(let error):
-            return error.localizedDescription
+            error.localizedDescription
         case .storage(let error):
-            return error.localizedDescription
+            error.localizedDescription
         }
     }
 }

--- a/Sources/TriforkHealthPlatformSDK/Data/Models/THPJWT.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Models/THPJWT.swift
@@ -16,21 +16,25 @@ public struct THPJWT {
     /// This value is optional.
     public let issuer: String?
 
-    /// Failable initializer for `JWT`.
+    /// The value of the `login_provider` parameter.
+    /// This value is optional
+    public let loginProvider: String?
+}
+
+extension THPJWT {
+    /// Failable initializer for `THPJWT`.
     /// This will only succeed if the token contains a `sub` parameter.
     public init?(token: String) {
-        self.token = token
-        if let userId = token.userId {
-            self.userId = userId
-        } else {
-            return nil
-        }
+        let parsedToken = THPJWTDecoder.decode(jwtToken: token)
+        guard let userId = parsedToken.userId else { return nil }
+        self.init(
+            token: token,
+            userId: userId,
+            expireDate: parsedToken.expireTimestamp.map { Date(timeIntervalSince1970: $0) },
+            issuer: parsedToken.issuer,
+            loginProvider: parsedToken.loginProvider
+        )
+    }
 
-        if let expireTimestamp = token.expireTimestamp {
-            self.expireDate = Date(timeIntervalSince1970: expireTimestamp)
-        } else {
-            self.expireDate = nil
-        }
-        self.issuer = token.issuer
     }
 }

--- a/Sources/TriforkHealthPlatformSDK/Data/Models/THPJWT.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Models/THPJWT.swift
@@ -36,5 +36,14 @@ extension THPJWT {
         )
     }
 
+    /// Returns a specific value from key-value pairs obtained after parsing the token, in case there is no public accessor for it. Returned value is automatically casted to the specified return type `Value`.
+    ///
+    /// - Parameters:
+    ///   - key: The `String` representing the key of the value we want to access
+    /// - Returns: The value in the token for the specified `key` casted as `Value`, or `nil` if the value is missing or the wrong type is requested.
+    ///
+    /// - Note: This function requires parsing the token to a `[String: Any]` instance in order to access the key-value pairs, which might be a long calculation. We strongly recommend storing the return value to avoid repeated invocations of this function.
+    public subscript<Value>(_ key: String) -> Value? {
+        THPJWTDecoder.decode(jwtToken: token)[key] as? Value
     }
 }

--- a/Sources/TriforkHealthPlatformSDK/Data/Models/THPJWT.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Models/THPJWT.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 /// Wrapper class for a `THPJWTString`. This class is used to guarantee that a token always is accompanied with a valid userId and expire timestamp.
-public struct THPJWT {
-    /// JWT token
+public struct THPJWT: Sendable {
+    /// Original JWT token, as retrieved for the identity provider.
     public let token: String
 
     /// User ID from token's `sub` parameter

--- a/Sources/TriforkHealthPlatformSDK/Data/Models/THPJWT.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Models/THPJWT.swift
@@ -1,10 +1,3 @@
-//
-//  File.swift
-//
-//
-//  Created by Nicolai Harbo on 20/06/2023.
-//
-
 import Foundation
 
 /// Wrapper class for a `THPJWTString`. This class is used to guarantee that a token always is accompanied with a valid userId and expire timestamp.

--- a/Sources/TriforkHealthPlatformSDK/Data/Protocols/THPAuth.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Protocols/THPAuth.swift
@@ -1,10 +1,3 @@
-//
-//  THPAuthProtocol.swift
-//  
-//
-//  Created by Nicolai Harbo on 20/06/2023.
-//
-
 import TIM
 import UIKit
 

--- a/Sources/TriforkHealthPlatformSDK/Data/Protocols/THPAuth.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Protocols/THPAuth.swift
@@ -1,7 +1,7 @@
 import TIM
 import UIKit
 
-public protocol THPAuth {
+public protocol THPAuth: Actor {
     /// Performs OAuth login or signup with OpenID Connect by presenting a `SFSafariViewController` on the `presentingViewController`
     ///
     /// The `refreshToken` property will be available after this, which can be used to encrypt and store it in the secure store by the `storage` namespace.
@@ -22,7 +22,7 @@ public protocol THPAuth {
     /// Handles redirect from the `SFSafariViewController`. The return value determines whether the URL was handled successfully.
     /// - Parameter url: The url that was directed to the app.
     @discardableResult
-    func handleRedirect(url: URL) -> Bool
+    func handleRedirect(url: URL) async -> Bool
     
     /// Logs in using biometric login. This can only be done if the user has stored the refresh token with a password after calling `performOpenIDConnectLogin` AND enabled biometric protection for it.
     /// - Parameters:
@@ -42,11 +42,11 @@ public protocol THPAuth {
     
     /// Logs out the user of the current session, clearing the auth state with active tokens
     /// - Parameter clearUser: Clears all securely stored data
-    func logout(clearUser: Bool)
+    func logout(clearUser: Bool) async
     
     /// Gets the refresh token (JWT) from the current session if available
-    var refreshToken: THPJWT? { get }
+    var refreshToken: THPJWT? { get async }
     
     /// Indicates whether the user as a valid auth state
-    var isLoggedIn: Bool { get }
+    var isLoggedIn: Bool { get async }
 }

--- a/Sources/TriforkHealthPlatformSDK/Data/Protocols/THPUserStorage.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Protocols/THPUserStorage.swift
@@ -1,30 +1,30 @@
 import Foundation
 import TIM
 
-public protocol THPUserStorage {
+public protocol THPUserStorage: Actor {
     /// The current users userId
-    var userId: String? { get }
+    var userId: String? { get async }
     
     /// Enables biometric protection access for refresh token.
     /// - Parameters:
     ///   - password: The password that was used to store the refresh token.
     ///   - userId: The `userId` for the refresh token.
-    func enableBiometricAccessForRefreshToken(password: String) async throws -> Void
+    func enableBiometricAccessForRefreshToken(password: String) async throws
     
     /// Checks whether the logged in user has stored a refresh token with biometric protection access.
-    func hasBiometricAccessEnabled() -> Bool
+    func hasBiometricAccessEnabled() async -> Bool
     
     /// Disables biometric protection access for refresh token.
-    func disableBiometricAccess()
+    func disableBiometricAccess() async
     
     ///  Clears all securely stored data for the logged in user
-    func clearUser()
+    func clearUser() async
     
     /// Stores refresh token with a new password and removes current biometric access for potential previous refresh token.
     /// - Parameters:
     ///   - refreshToken: The refresh token.
     ///   - newPassword: The new password that needs a new encryption key.
-    func storeRefreshToken(_ refreshToken: THPJWT, withNewPassword newPassword: String) async throws -> Void
+    func storeRefreshToken(_ refreshToken: THPJWT, withNewPassword newPassword: String) async throws
     
     /// Gets a stored refresh token for a `userId` and a `password`
     /// - Parameters:

--- a/Sources/TriforkHealthPlatformSDK/Data/Protocols/THPUserStorage.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Protocols/THPUserStorage.swift
@@ -1,10 +1,3 @@
-//
-//  THPUserStorageProtocol.swift
-//  
-//
-//  Created by Nicolai Harbo on 20/06/2023.
-//
-
 import Foundation
 import TIM
 

--- a/Sources/TriforkHealthPlatformSDK/Data/Protocols/TIMManager.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Protocols/TIMManager.swift
@@ -1,10 +1,3 @@
-//
-//  File.swift
-//  
-//
-//  Created by Nicolai Harbo on 20/06/2023.
-//
-
 import Combine
 import Foundation
 import TIM

--- a/Sources/TriforkHealthPlatformSDK/Data/Protocols/TIMManager.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Protocols/TIMManager.swift
@@ -1,5 +1,3 @@
-import Combine
-import Foundation
 import TIM
 import TIMEncryptedStorage
 import UIKit

--- a/Sources/TriforkHealthPlatformSDK/Data/Protocols/TIMManager.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Protocols/TIMManager.swift
@@ -2,29 +2,28 @@ import TIM
 import TIMEncryptedStorage
 import UIKit
 
-protocol TIMManager {
-    
+protocol TIMManager: Actor {
     // MARK: - Auth
     
-    func performOpenIDConnectFlow(flow: THPAuthenticationFlow, presentingViewController: UIViewController) -> AnyPublisher<JWT, THPError>
-    func performOpenIDConnectFlow(flow: THPAuthenticationFlow) -> AnyPublisher<JWT, THPError>
-    @discardableResult
+    func performOpenIDConnectFlow(flow: THPAuthenticationFlow, presentingViewController: UIViewController) async throws -> JWT
+    func performOpenIDConnectFlow(flow: THPAuthenticationFlow) async throws -> JWT
+    @discardableResult 
     func handleRedirect(url: URL) -> Bool
-    func loginWithBiometricId(userId: String, storeNewRefreshToken: Bool) -> AnyPublisher<JWT, THPError>
-    func loginWithPassword(userId: String, password: String, storeNewRefreshToken: Bool) -> AnyPublisher<JWT, THPError>
+    func loginWithBiometricId(userId: String, storeNewRefreshToken: Bool) async throws -> JWT
+    func loginWithPassword(userId: String, password: String, storeNewRefreshToken: Bool) async throws -> JWT
     func clearAllUsers(except userId: String?)
-    func accessToken(forceRefresh: Bool) -> AnyPublisher<JWT, THPError>
-    func getStoredRefreshToken(userId: String, password: String) -> AnyPublisher<JWT, THPError>
+    func accessToken(forceRefresh: Bool) async throws -> JWT
+    func getStoredRefreshToken(userId: String, password: String) async throws -> JWT
     var refreshToken: JWT? { get }
     var isLoggedIn: Bool { get }
     
     // MARK: - Storage
     
     var userId: String? { get }
-    func enableBiometricAccessForRefreshToken(password: String, userId: String) -> AnyPublisher<Void, THPError>
+    func enableBiometricAccessForRefreshToken(password: String, userId: String) async throws -> Void
     func hasBiometricAccessForRefreshToken(userId: String) -> Bool
     func disableBiometricAccessForRefreshToken(userId: String)
-    func storeRefreshToken(_ refreshToken: THPJWT, withNewPassword newPassword: String) -> AnyPublisher<TIMESKeyCreationResult, THPError>
+    func storeRefreshToken(_ refreshToken: THPJWT, withNewPassword newPassword: String) async throws -> TIMESKeyCreationResult
     
     // MARK: - Mixed (for SDK simplicity)
     

--- a/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Authentication/THPAuthEntity.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Authentication/THPAuthEntity.swift
@@ -1,183 +1,78 @@
 import Foundation
 import UIKit
 
-public struct THPAuthEntity {
-    
-    private let timManager: TIMManager?
+public final actor THPAuthEntity: THPAuth {
+    private let timManager: TIMManager
     
     init(timManager: TIMManager) {
         self.timManager = timManager
     }
-}
-
-extension THPAuthEntity: THPAuth {
     
     public func performOpenIDConnectFlow(
         flow: THPAuthenticationFlow,
         presentingViewController: UIViewController
     ) async throws -> String {
-        guard let timManager else {
-            fatalError("You have to call the `configure(configuration:)` method before using \(#function)")
-        }
-        var cancellable: AnyCancellable?
-        var userId: String?
-        
-        return try await withCheckedThrowingContinuation { continuation in
-            cancellable = timManager.performOpenIDConnectFlow(flow: flow, presentingViewController: presentingViewController)
-                .sink { completion in
-                    switch completion {
-                    case .failure(let error):
-                        continuation.resume(throwing: error)
-                        
-                    case .finished:
-                        guard let userId else {
-                            continuation.resume(throwing: THPError.auth(.authStateNil))
-                            return
-                        }
-                        
-                        // New login succeeded. Since we only support one user login we will clear all other ids on this device.
-                        timManager.clearAllUsers(except: userId)
-                        continuation.resume(returning: userId)
-                    }
-                    cancellable?.cancel()
-                } receiveValue: { accessToken in
-                    userId = accessToken.userId
-                }
-        }
+        try await timManager.performOpenIDConnectFlow(flow: flow, presentingViewController: presentingViewController).userId
     }
     
     public func performOpenIDConnectFlow(flow: THPAuthenticationFlow) async throws -> String {
-        guard let timManager else {
-            fatalError("You have to call the `configure(configuration:)` method before using \(#function)")
-        }
-        var cancellable: AnyCancellable?
-        var userId: String?
-
-        return try await withCheckedThrowingContinuation { continuation in
-            cancellable = timManager.performOpenIDConnectFlow(flow: flow)
-                .sink { completion in
-                    switch completion {
-                    case .failure(let error):
-                        continuation.resume(throwing: error)
-
-                    case .finished:
-                        guard let userId else {
-                            continuation.resume(throwing: THPError.auth(.authStateNil))
-                            return
-                        }
-
-                        // New login succeeded. Since we only support one user login we will clear all other ids on this device.
-                        timManager.clearAllUsers(except: userId)
-                        continuation.resume(returning: userId)
-                    }
-                    cancellable?.cancel()
-                } receiveValue: { accessToken in
-                    userId = accessToken.userId
-                }
-        }
+        try await timManager.performOpenIDConnectFlow(flow: flow).userId
     }
     
     @discardableResult
-    public func handleRedirect(url: URL) -> Bool {
-        guard let timManager else {
-            fatalError("You have to call the `configure(configuration:)` method before using \(#function)")
-        }
-        return timManager.handleRedirect(url: url)
+    public func handleRedirect(url: URL) async -> Bool {
+        await timManager.handleRedirect(url: url)
     }
     
     public func loginWithBiometricId(storeNewRefreshToken: Bool) async throws -> THPJWT {
-        guard let timManager else {
-            fatalError("You have to call the `configure(configuration:)` method before using \(#function)")
-        }
-        
-        guard let userId = timManager.userId else {
+        guard let userId = await timManager.userId else {
             fatalError("userId is missing!")
         }
         
-        var cancellable: AnyCancellable?
-        return try await withCheckedThrowingContinuation { continuation in
-            cancellable = timManager.loginWithBiometricId(userId: userId, storeNewRefreshToken: storeNewRefreshToken)
-                .mapError { $0 }
-                .sink(
-                    receiveCompletion: { completion in
-                        if case let .failure(error) = completion {
-                            continuation.resume(throwing: error)
-                        }
-                        cancellable?.cancel()
-                    }, receiveValue: { accessToken in
-                        continuation.resume(returning: THPJWT(token: accessToken.token)!)
-                    }
-                )
+        let result = try await timManager.loginWithBiometricId(userId: userId, storeNewRefreshToken: storeNewRefreshToken)
+        if let token = THPJWT(token: result.token) {
+            return token
+        } else {
+            throw THPError.auth(.failedToValidateIDToken)
         }
     }
     
     public func loginWithPassword(password: String, storeNewRefreshToken: Bool) async throws -> THPJWT {
-        guard let timManager else {
-            fatalError("You have to call the `configure(configuration:)` method before using \(#function)")
-        }
-        
-        guard let userId = timManager.userId else {
+        guard let userId = await timManager.userId else {
             fatalError("userId is missing!")
         }
         
-        var cancellable: AnyCancellable?
-        return try await withCheckedThrowingContinuation { continuation in
-            cancellable = timManager.loginWithPassword(userId: userId, password: password, storeNewRefreshToken: storeNewRefreshToken)
-                .mapError { $0 }
-                .sink(
-                    receiveCompletion: { completion in
-                        if case let .failure(error) = completion {
-                            continuation.resume(throwing: error)
-                        }
-                        cancellable?.cancel()
-                    }, receiveValue: { accessToken in
-                        continuation.resume(returning: THPJWT(token: accessToken.token)!)
-                    }
-                )
+        let result = try await timManager.loginWithPassword(userId: userId, password: password, storeNewRefreshToken: storeNewRefreshToken)
+        if let token = THPJWT(token: result.token) {
+            return token
+        } else {
+            throw THPError.auth(.failedToValidateIDToken)
         }
     }
     
     public func getAccessToken(forceRefresh: Bool = false) async throws -> THPJWT {
-        guard let timManager else {
-            fatalError("You have to call the `configure(configuration:)` method before using \(#function)")
+        let result = try await timManager.accessToken(forceRefresh: forceRefresh)
+        if let token = THPJWT(token: result.token) {
+            return token
+        } else {
+            throw THPError.auth(.failedToValidateIDToken)
         }
-        
-        var cancellable: AnyCancellable?
-        return try await withCheckedThrowingContinuation { continuation in
-            cancellable = timManager.accessToken(forceRefresh: forceRefresh)
-                .mapError { $0 }
-                .sink(
-                    receiveCompletion: { completion in
-                        if case let .failure(error) = completion {
-                            continuation.resume(throwing: error)
-                        }
-                        cancellable?.cancel()
-                    }, receiveValue: { accessToken in
-                        continuation.resume(returning: THPJWT(token: accessToken.token)!)
-                    }
-                )
-        }
+    }
+
+    public func logout(clearUser: Bool) async {
+        await timManager.logout(clearUser: clearUser)
     }
     
     public var refreshToken: THPJWT? {
-        guard let timManager else {
-            fatalError("You have to call the `configure(configuration:)` method before using \(#function)")
+        get async {
+            guard let token = await timManager.refreshToken?.token else { return nil }
+            return THPJWT(token: token)
         }
-        guard let token = timManager.refreshToken?.token else { return nil }
-        return THPJWT(token: token)
-    }
-    
-    public func logout(clearUser: Bool) {
-        guard let timManager else {
-            fatalError("You have to call the `configure(configuration:)` method before using \(#function)")
-        }
-        timManager.logout(clearUser: clearUser)
     }
     
     public var isLoggedIn: Bool {
-        guard let timManager else {
-            fatalError("You have to call the `configure(configuration:)` method before using \(#function)")
+        get async {
+            await timManager.isLoggedIn
         }
-        return timManager.isLoggedIn
     }
 }

--- a/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Authentication/THPAuthEntity.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Authentication/THPAuthEntity.swift
@@ -1,10 +1,3 @@
-//
-//  THPAuth.swift
-//  
-//
-//  Created by Nicolai Harbo on 15/06/2023.
-//
-
 import Combine
 import Foundation
 import UIKit

--- a/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Authentication/THPAuthEntity.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Authentication/THPAuthEntity.swift
@@ -1,4 +1,3 @@
-import Combine
 import Foundation
 import UIKit
 

--- a/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Storage/THPUserStorageEntity.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Storage/THPUserStorageEntity.swift
@@ -1,10 +1,3 @@
-//
-//  File.swift
-//  
-//
-//  Created by Nicolai Harbo on 20/06/2023.
-//
-
 import Combine
 import Foundation
 

--- a/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Storage/THPUserStorageEntity.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Storage/THPUserStorageEntity.swift
@@ -1,114 +1,54 @@
 import Combine
 import Foundation
 
-public struct THPUserStorageEntity {
-    
-    private let timManager: TIMManager?
+public final actor THPUserStorageEntity: THPUserStorage {
+    private let timManager: TIMManager
     
     init(timManager: TIMManager) {
         self.timManager = timManager
     }
-}
-
-extension THPUserStorageEntity: THPUserStorage {
    
     public var userId: String? {
-        guard let timManager else {
-            fatalError("You have to call the `configure(configuration:)` method before using \(#function)")
+        get async {
+            await timManager.userId
         }
-        return timManager.userId
     }
     
-    public func enableBiometricAccessForRefreshToken(password: String) async throws -> Void {
-        guard let timManager else {
-            fatalError("You have to call the `configure(configuration:)` method before using \(#function)")
-        }
-        
-        guard let userId else {
+    public func enableBiometricAccessForRefreshToken(password: String) async throws {
+        guard let userId = await timManager.userId else {
             fatalError("You must have a logged in user to enable Biometrics")
         }
-        
-        var cancellable: AnyCancellable?
-        return try await withCheckedThrowingContinuation { continuation in
-            cancellable = timManager.enableBiometricAccessForRefreshToken(password: password, userId: userId)
-                .sink(
-                    receiveCompletion: { completion in
-                        if case let .failure(error) = completion {
-                            continuation.resume(throwing: error)
-                        }
-                        cancellable?.cancel()
-                    }, receiveValue: { _ in
-                        continuation.resume()
-                    }
-                )
-        }
+        try await timManager.enableBiometricAccessForRefreshToken(password: password, userId: userId)
     }
     
-    public func hasBiometricAccessEnabled() -> Bool {
-        guard let timManager else {
-            fatalError("You have to call the `configure(configuration:)` method before using \(#function)")
-        }
-        
-        guard let userId else {
+    public func hasBiometricAccessEnabled() async -> Bool {
+        guard let userId = await timManager.userId else {
             fatalError("You must have a logged in user to call \(#function)")
         }
-        return timManager.hasBiometricAccessForRefreshToken(userId: userId)
+        return await timManager.hasBiometricAccessForRefreshToken(userId: userId)
     }
     
-    public func disableBiometricAccess() {
-        guard let timManager else {
-            fatalError("You have to call the `configure(configuration:)` method before using \(#function)")
-        }
-        
-        guard let userId else {
+    public func disableBiometricAccess() async {
+        guard let userId = await timManager.userId else {
             fatalError("You must have a logged in user to disable Biometrics")
         }
-        timManager.disableBiometricAccessForRefreshToken(userId: userId)
+        await timManager.disableBiometricAccessForRefreshToken(userId: userId)
     }
     
-    public func clearUser() {
-        timManager?.clearAllUsers(except: nil)
+    public func clearUser() async {
+        await timManager.clearAllUsers(except: nil)
     }
     
-    public func storeRefreshToken(_ refreshToken: THPJWT, withNewPassword newPassword: String) async throws -> Void {
-        guard let timManager else {
-            fatalError("You have to call the `configure(configuration:)` method before using \(#function)")
-        }
-        
-        var cancellable: AnyCancellable?
-        return try await withCheckedThrowingContinuation { continuation in
-            cancellable = timManager.storeRefreshToken(refreshToken, withNewPassword: newPassword)
-                .sink(
-                    receiveCompletion: { completion in
-                        if case let .failure(error) = completion {
-                            continuation.resume(throwing: error)
-                        }
-                        cancellable?.cancel()
-                    }, receiveValue: { _ in
-                        continuation.resume()
-                    }
-                )
-        }
+    public func storeRefreshToken(_ refreshToken: THPJWT, withNewPassword newPassword: String) async throws {
+        _ = try await timManager.storeRefreshToken(refreshToken, withNewPassword: newPassword)
     }
     
     public func getStoredRefreshToken(for userId: String, with password: String) async throws -> THPJWT {
-        guard let timManager else {
-            fatalError("You have to call the `configure(configuration:)` method before using \(#function)")
-        }
-        
-        var cancellable: AnyCancellable?
-        return try await withCheckedThrowingContinuation { continuation in
-            cancellable = timManager.getStoredRefreshToken(userId: userId, password: password)
-                .sink(
-                    receiveCompletion: { completion in
-                        if case let .failure(error) = completion {
-                            continuation.resume(throwing: error)
-                        }
-                        cancellable?.cancel()
-                    }, receiveValue: { accessToken in
-                        continuation.resume(returning: THPJWT(token: accessToken.token)!)
-                    }
-                )
+        let jwt = try await timManager.getStoredRefreshToken(userId: userId, password: password)
+        if let token = THPJWT(token: jwt.token) {
+            return token
+        } else {
+            throw THPError.auth(.failedToGetRefreshToken)
         }
     }
 }

--- a/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/TIMManagerEntity.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/TIMManagerEntity.swift
@@ -5,24 +5,17 @@ import TIM
 import TIMEncryptedStorage
 import UIKit
 
-public class TIMManagerEntity {
-    
+public final actor TIMManagerEntity: TIMManager {
     private let thpConfiguration: THPConfiguration
-    private let customOIDExternalUserAgent: OIDExternalUserAgent?
+    private let customOIDExternalUserAgent: THPOIDExternalUserAgent?
     
     public init(
         thpConfiguration: THPConfiguration,
-        customOIDExternalUserAgent: OIDExternalUserAgent?
+        presentingViewController: UIViewController
     ) {
         self.thpConfiguration = thpConfiguration
-        self.customOIDExternalUserAgent = customOIDExternalUserAgent
-        configureTIM(for: .signin)
+        self.customOIDExternalUserAgent = THPOIDExternalUserAgent(presenting: presentingViewController)
     }
-}
-
-// MARK: - Input
-
-extension TIMManagerEntity: TIMManager {
     
     // MARK: - Auth
     
@@ -34,50 +27,38 @@ extension TIMManagerEntity: TIMManager {
         TIM.auth.isLoggedIn
     }
     
-    func performOpenIDConnectFlow(flow: THPAuthenticationFlow, presentingViewController: UIViewController) -> AnyPublisher<JWT, THPError> {
+    func performOpenIDConnectFlow(flow: THPAuthenticationFlow, presentingViewController: UIViewController) async throws -> JWT {
         configureTIM(for: flow)
-        return TIM.auth.performOpenIDConnectLogin(presentingViewController: presentingViewController)
-            .mapError { $0.asTHPError() }
-            .eraseToAnyPublisher()
+        return try await TIM.auth.performOpenIDConnectLogin(presentingViewController: presentingViewController).value
     }
     
-    func performOpenIDConnectFlow(flow: THPAuthenticationFlow) -> AnyPublisher<JWT, THPError> {
+    func performOpenIDConnectFlow(flow: THPAuthenticationFlow) async throws -> JWT {
         configureTIM(for: flow)
-        return TIM.auth.performOpenIDConnectLogin()
-            .mapError { $0.asTHPError() }
-            .eraseToAnyPublisher()
+        return try await TIM.auth.performOpenIDConnectLogin().value
     }
     
     func handleRedirect(url: URL) -> Bool {
         TIM.auth.handleRedirect(url: url)
     }
     
-    func loginWithBiometricId(userId: String, storeNewRefreshToken: Bool) -> AnyPublisher<JWT, THPError> {
-        TIM.auth.loginWithBiometricId(userId: userId, storeNewRefreshToken: storeNewRefreshToken, willBeginNetworkRequests: nil)
-            .mapError { $0.asTHPError() }
-            .eraseToAnyPublisher()
+    func loginWithBiometricId(userId: String, storeNewRefreshToken: Bool) async throws -> JWT {
+        try await TIM.auth.loginWithBiometricId(userId: userId, storeNewRefreshToken: storeNewRefreshToken, willBeginNetworkRequests: nil).value
     }
     
-    func loginWithPassword(userId: String, password: String, storeNewRefreshToken: Bool) -> AnyPublisher<JWT, THPError> {
-        TIM.auth.loginWithPassword(userId: userId, password: password, storeNewRefreshToken: storeNewRefreshToken)
-            .mapError { $0.asTHPError() }
-            .eraseToAnyPublisher()
+    func loginWithPassword(userId: String, password: String, storeNewRefreshToken: Bool) async throws -> JWT {
+        try await TIM.auth.loginWithPassword(userId: userId, password: password, storeNewRefreshToken: storeNewRefreshToken).value
     }
     
     func clearAllUsers(except userId: String?) {
         TIM.storage.clearAllUsers(exceptUserId: userId)
     }
     
-    func accessToken(forceRefresh: Bool) -> AnyPublisher<JWT, THPError> {
-        TIM.auth.accessToken(forceRefresh: forceRefresh)
-            .mapError { $0.asTHPError() }
-            .eraseToAnyPublisher()
+    func accessToken(forceRefresh: Bool) async throws -> JWT {
+        try await TIM.auth.accessToken(forceRefresh: forceRefresh).value
     }
     
-    func getStoredRefreshToken(userId: String, password: String) -> AnyPublisher<JWT, THPError> {
-        TIM.storage.getStoredRefreshToken(userId: userId, password: password)
-            .mapError { $0.asTHPError() }
-            .eraseToAnyPublisher()
+    func getStoredRefreshToken(userId: String, password: String) async throws -> JWT {
+        try await TIM.storage.getStoredRefreshToken(userId: userId, password: password).value
     }
     
     // MARK: - Storage
@@ -86,10 +67,8 @@ extension TIMManagerEntity: TIMManager {
         TIM.storage.availableUserIds.first
     }
     
-    func enableBiometricAccessForRefreshToken(password: String, userId: String) -> AnyPublisher<Void, THPError> {
-        TIM.storage.enableBiometricAccessForRefreshToken(password: password, userId: userId)
-            .mapError { $0.asTHPError() }
-            .eraseToAnyPublisher()
+    func enableBiometricAccessForRefreshToken(password: String, userId: String) async throws {
+        try await TIM.storage.enableBiometricAccessForRefreshToken(password: password, userId: userId).value
     }
     
     func hasBiometricAccessForRefreshToken(userId: String) -> Bool {
@@ -100,11 +79,11 @@ extension TIMManagerEntity: TIMManager {
         TIM.storage.disableBiometricAccessForRefreshToken(userId: userId)
     }
     
-    func storeRefreshToken(_ refreshToken: THPJWT, withNewPassword newPassword: String) -> AnyPublisher<TIMESKeyCreationResult, THPError> {
-        let timToken = JWT(token: refreshToken.token)! // TODO: Fix forceunwrap!
-        return TIM.storage.storeRefreshToken(timToken, withNewPassword: newPassword)
-            .mapError { $0.asTHPError() }
-            .eraseToAnyPublisher()
+    func storeRefreshToken(_ refreshToken: THPJWT, withNewPassword newPassword: String) async throws -> TIMESKeyCreationResult {
+        guard let timToken = JWT(token: refreshToken.token) else {
+            throw THPError.auth(THPAuthError.failedToGetRefreshToken)
+        }
+        return try await TIM.storage.storeRefreshToken(timToken, withNewPassword: newPassword).value
     }
     
     // MARK: - Mixed (for SDK simplicity)
@@ -112,15 +91,19 @@ extension TIMManagerEntity: TIMManager {
     func logout(clearUser: Bool) {
         TIM.auth.logout()
         if clearUser {
-            self.clearAllUsers(except: nil)
+            clearAllUsers(except: nil)
         }
     }
 }
 
 // MARK: - Helpers
 
+extension JWT: @unchecked @retroactive Sendable {}
+extension Future: @unchecked @retroactive Sendable {}
+extension TIMESKeyCreationResult: @unchecked @retroactive Sendable {}
+
 extension TIMManagerEntity{
-    private func configureTIM(for flow: THPAuthenticationFlow) {
+    func configureTIM(for flow: THPAuthenticationFlow) {
         TIM.configure(
             configuration: buildConfiguration(
                 url: thpConfiguration.baseAuthURL,

--- a/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/TIMManagerEntity.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/TIMManagerEntity.swift
@@ -105,36 +105,21 @@ extension TIMESKeyCreationResult: @unchecked @retroactive Sendable {}
 extension TIMManagerEntity{
     func configureTIM(for flow: THPAuthenticationFlow) {
         TIM.configure(
-            configuration: buildConfiguration(
-                url: thpConfiguration.baseAuthURL,
-                scopes: thpConfiguration.scopes,
+            configuration: TIMConfiguration(
+                timBaseUrl: thpConfiguration.baseAuthURL,
                 realm: thpConfiguration.realm,
                 clientId: thpConfiguration.clientId,
-                redirectURL: thpConfiguration.redirectUrl,
-                flow: flow
+                redirectUri: URL(string: thpConfiguration.redirectUrl)!,
+                scopes: thpConfiguration.scopes,
+                encryptionMethod: .aesGcm,
+                additionalParameters: [
+                    "ui_locales": Locale.applicationLocale.identifier.split(separator: "-")[0].description,
+                    "prompt": "login",
+                    thpConfiguration.loginFlowKey: flow.rawValue
+                ]
             ),
             allowReconfigure: true,
             customOIDExternalUserAgent: customOIDExternalUserAgent
-        )
-    }
-    
-    private func buildConfiguration(url: URL, scopes: [String], realm: String, clientId: String, redirectURL: String, flow: THPAuthenticationFlow) -> TIMConfiguration {
-        
-        var params: [String: String] = [
-            "ui_locales": Locale.applicationLocale.identifier.split(separator: "-")[0].description,
-            "prompt": "login"
-        ]
-
-        params[thpConfiguration.loginFlowKey] = flow.rawValue
-        
-        return TIMConfiguration(
-            timBaseUrl: url,
-            realm: realm,
-            clientId: clientId,
-            redirectUri: URL(string: redirectURL)!,
-            scopes: scopes,
-            encryptionMethod: .aesGcm,
-            additionalParameters: params
         )
     }
 }

--- a/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/TIMManagerEntity.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/TIMManagerEntity.swift
@@ -1,10 +1,3 @@
-//
-//  TIMManager.swift
-//  
-//
-//  Created by Nicolai Harbo on 15/06/2023.
-//
-
 import AppAuth
 import Combine
 import Foundation

--- a/Sources/TriforkHealthPlatformSDK/Implementations/UI/SFSafariViewController/SafariWebView.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/UI/SFSafariViewController/SafariWebView.swift
@@ -1,10 +1,3 @@
-//
-//  File.swift
-//  
-//
-//  Created by Nicolai Harbo on 31/08/2023.
-//
-
 import SwiftUI
 import SafariServices
 

--- a/Sources/TriforkHealthPlatformSDK/Implementations/UI/SFSafariViewController/SafariWebView.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/UI/SFSafariViewController/SafariWebView.swift
@@ -22,7 +22,7 @@ struct SafariWebView: UIViewControllerRepresentable {
     func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) { }
     
     class Coordinator: NSObject, SFSafariViewControllerDelegate {
-        var parent: SafariWebView
+        let parent: SafariWebView
         
         init(_ parent: SafariWebView) {
             self.parent = parent

--- a/Sources/TriforkHealthPlatformSDK/Implementations/UI/SFSafariViewController/SafariWebView.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/UI/SFSafariViewController/SafariWebView.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import SafariServices
+import SwiftUI
 
 struct SafariWebView: UIViewControllerRepresentable {
     let url: URL

--- a/Sources/TriforkHealthPlatformSDK/Implementations/UI/SFSafariViewController/THPIODCSafariWebView.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/UI/SFSafariViewController/THPIODCSafariWebView.swift
@@ -1,8 +1,7 @@
 import SwiftUI
 
 public struct THPIODCSafariWebView: View {
-    
-    let url: URL
+    private let url: URL
 
     public init(url: URL) {
         self.url = url

--- a/Sources/TriforkHealthPlatformSDK/Implementations/UI/SFSafariViewController/THPIODCSafariWebView.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/UI/SFSafariViewController/THPIODCSafariWebView.swift
@@ -1,10 +1,3 @@
-//
-//  SwiftUIView.swift
-//  
-//
-//  Created by Nicolai Harbo on 31/08/2023.
-//
-
 import SwiftUI
 
 public struct THPIODCSafariWebView: View {

--- a/Sources/TriforkHealthPlatformSDK/THP.swift
+++ b/Sources/TriforkHealthPlatformSDK/THP.swift
@@ -49,11 +49,6 @@ public final class THP {
         }
     }
     
-    /// Allows you to read the configuration
-    public var configuration: THPConfiguration? {
-        return _configuration
-    }
-    
 //    /// Gives you access to medical data for the logged in user
 //    public var data: THPData {
 //        if let dataInstance = _data {

--- a/Sources/TriforkHealthPlatformSDK/THP.swift
+++ b/Sources/TriforkHealthPlatformSDK/THP.swift
@@ -2,9 +2,9 @@
 public final actor THP {
     
     /// The shared instance of the `TriforkHealthPlatformSDK` which should be used for all interactions.
-    public static var shared: THP = THP()
+    public static let shared: THP = THP()
     
-    // Singleton init
+    /// Singleton init
     private init() { }
     
     // MARK: - Private properties

--- a/Sources/TriforkHealthPlatformSDK/THP.swift
+++ b/Sources/TriforkHealthPlatformSDK/THP.swift
@@ -1,5 +1,5 @@
 /// Main entrypoint for the SDK
-public final class THP {
+public final actor THP {
     
     /// The shared instance of the `TriforkHealthPlatformSDK` which should be used for all interactions.
     public static var shared: THP = THP()
@@ -33,30 +33,21 @@ public final class THP {
     
     /// Gives you access to the auth features of the SDK.
     public var auth: THPAuth {
-        if let authInstance = _auth {
-            return authInstance
+        if let _auth {
+            return _auth
         } else {
-            fatalError("You have to call the `configure(configuration:)` method before using `\(#function)`")
+            fatalError("You have to call the `configure(_ configuration:)` method before using `\(#function)`")
         }
     }
     
     /// Gives you access to the user storage features of the SDK.
     public var userStorage: THPUserStorage {
-        if let storageInstance = _userStorage {
-            return storageInstance
+        if let _userStorage {
+            return _userStorage
         } else {
-            fatalError("You have to call the `configure(configuration:)` method before using `\(#function)`")
+            fatalError("You have to call the `configure(_ configuration:)` method before using `\(#function)`")
         }
     }
-    
-//    /// Gives you access to medical data for the logged in user
-//    public var data: THPData {
-//        if let dataInstance = _data {
-//            return dataInstance
-//        } else {
-//            fatalError("You have to call the `configure(configuration:)` method before using `\(#function)`")
-//        }
-//    }
 }
 
 

--- a/Sources/TriforkHealthPlatformSDK/THP.swift
+++ b/Sources/TriforkHealthPlatformSDK/THP.swift
@@ -11,28 +11,24 @@ public final class THP {
     private var timManager: TIMManager?
     private var _auth: THPAuth?
     private var _userStorage: THPUserStorage?
-    private var _configuration: THPConfiguration?
-}
+    
+    // MARK: - Public non-modifiable properties
+    private(set) public var configuration: THPConfiguration?
 
-// MARK: - Input
-
-extension THP {
     /// Configures the `TriforkHealthPlatformSDK`
     /// The configuration needs to be called before any other functionalities can be used
     /// You should only call this function once.
     /// - Parameter configuration: The actual configuration
-    /// - Parameter customOIDExternalUserAgent: The actual configuration
-    public func configure(
-        configuration: THPConfiguration,
-        customOIDExternalUserAgent: OIDExternalUserAgent? = nil
-    ) {
-        timManager = TIMManagerEntity(
+    public func configure(_ configuration: THPConfiguration) async {
+        let timManager = await TIMManagerEntity(
             thpConfiguration: configuration,
-            customOIDExternalUserAgent: customOIDExternalUserAgent
+            presentingViewController: .init()
         )
-        _auth = THPAuthEntity(timManager: timManager!)
-        _userStorage = THPUserStorageEntity(timManager: timManager!)
-        _configuration = configuration
+        await timManager.configureTIM(for: .signin)
+        self.configuration = configuration
+        self.timManager = timManager
+        _auth = THPAuthEntity(timManager: timManager)
+        _userStorage = THPUserStorageEntity(timManager: timManager)
     }
     
     /// Gives you access to the auth features of the SDK.

--- a/Sources/TriforkHealthPlatformSDK/THP.swift
+++ b/Sources/TriforkHealthPlatformSDK/THP.swift
@@ -1,5 +1,3 @@
-import AppAuth
-
 /// Main entrypoint for the SDK
 public final class THP {
     

--- a/Sources/TriforkHealthPlatformSDK/THP.swift
+++ b/Sources/TriforkHealthPlatformSDK/THP.swift
@@ -7,6 +7,13 @@ public final actor THP {
     /// Singleton init
     private init() { }
     
+    /// Default initializer
+    /// - parameter configuration:
+    public init(configuration: THPConfiguration) {
+        self.init()
+        Task { await configure(configuration) }
+    }
+    
     // MARK: - Private properties
     private var timManager: TIMManager?
     private var _auth: THPAuth?
@@ -14,12 +21,14 @@ public final actor THP {
     
     // MARK: - Public non-modifiable properties
     private(set) public var configuration: THPConfiguration?
+    private(set) public var isConfigured: Bool = false
 
     /// Configures the `TriforkHealthPlatformSDK`
     /// The configuration needs to be called before any other functionalities can be used
     /// You should only call this function once.
     /// - Parameter configuration: The actual configuration
     public func configure(_ configuration: THPConfiguration) async {
+        isConfigured = false
         let timManager = await TIMManagerEntity(
             thpConfiguration: configuration,
             presentingViewController: .init()
@@ -29,6 +38,7 @@ public final actor THP {
         self.timManager = timManager
         _auth = THPAuthEntity(timManager: timManager)
         _userStorage = THPUserStorageEntity(timManager: timManager)
+        isConfigured = true
     }
     
     /// Gives you access to the auth features of the SDK.
@@ -49,9 +59,3 @@ public final actor THP {
         }
     }
 }
-
-
-// TODO: Tasks that needs to be done
-// - Add documentation for the THPConfiguration file
-// - Add documentation in Github Readme, on how to use the SDK for logging in/signing up.
-// - Set up Apollo to prepare for handling data, when BFF is ready to deliver data instaed of view components

--- a/Tests/TriforkHealthPlatformSDKTests/thp_ios_sdkTests.swift
+++ b/Tests/TriforkHealthPlatformSDKTests/thp_ios_sdkTests.swift
@@ -1,8 +1,0 @@
-import XCTest
-@testable import TriforkHealthPlatformSDK
-
-final class thp_ios_sdkTests: XCTestCase {
-    func testExample() throws {
-//        THP.shared.
-    }
-}


### PR DESCRIPTION
## Summary

In this PR we implement the necessary changes for the library to adopt Swift 6 strict concurrency. Some code clean-up and streamlining has also been implemented.

## Changes

The amount of changes is too extensive to thoroughly list them here. A quick summary is the following.

- iOS minimum version has been increased to 15 or higher to enable usage of `async/await` syntax.
- Swift minimum version has been increased to 6.2 to take full advantage of new features and strict concurrency.
- All functions returning `AnyPublisher<Value, Error>` have been converted to `async throws` functions returning `Value` and throwing the same `Error` type as the one wrapped in the `Publisher`.
- `THPAuth`, `THPUserStorage` and `TIMManager` (and their implementations) have been converted from `class` to `actor`, and all properties and functions are isolated and marked as `async`.
- `THPAuthenticationFlow`, `THPConfiguration` and `THPJWT` are now conforming to `Sendable`.
- Implementation of `THPJWT` has been expanded to include new properties, and a new subscript function to access custom key-value pairs in the token.
- THP function `configure(configuration:customOIDExternalUserAgent:)` has been changed to `configure(_ configuration:)` for simplicity.
- API has been streamlined and simplified where possible.
- Added documentation to README.md file.

## Release

This is intended to be version 1.0 of the library, and will be tagged and marked as a release in GitHub after merge.