### PR TITLE
[Refactor] Typed errors

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "557939a2717d7a64b986c70299fe6bf4476150b358186cfcdb9d1a31c28a4303",
+  "originHash" : "3fd4e40dfc52cc8bb799f447aa7b167a71eac78cf736db9b433daf1bde4b8d16",
   "pins" : [
     {
       "identity" : "appauth-ios",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Trifork Health Platform iOS SDK is a Swift library wrapping [Trifork's Identity 
 
 | Version | Requirements            |
 |:--------|:------------------------|
-| 1.0.0   | Swift 6.2+<br>iOS 15.0+ |
+| 1.0.0+  | Swift 6.2+<br>iOS 15.0+ |
 
 ## Installation
 
@@ -297,12 +297,14 @@ await THP.shared.auth.logout(clearUser: true)
 
 ### Understanding the errors
 
-`THP` can throw a large set of errors, because of the different dependencies. All errors are wrapped within the `THPError` `enum`, with specific cases `auth` and `storage`, depending on the area that throws the error. The errors will contain other errors coming from the heart of the framework and there are a couple of levels in this:
+`THP` can throw a large set of errors, because of the different dependencies. All errors are wrapped within the `THPError` `enum`, with specific cases `auth` and `storage`, depending on the area that throws the error, and then two generic `missingUserId` and `unknown` cases. The errors will contain other errors coming from the heart of the framework and there are a couple of levels in this:
 
 ```swift
 enum THPError: Error {
     case auth(THPAuthError)
     case storage(THPStorageError)
+    case missingUserId(String)
+    case unknown
 }
 ```
 
@@ -351,7 +353,11 @@ Other errors should of course still be handled, but they can be handled in a mor
 
 `THP` depends on `TIM`, which in turn depends on `AppAuth` and `TIMEncryptedStorage`. In essence, `THP` wraps `TIM` usage for common use cases (see sections above), such that signing in/up and encrypted storage are easy to manage.
 
-## Breaking changes from `0.x`
+## Changes from `1.0.0` to `1.1.0`
+
+* Generic `Error` instances are now mapped to `THPError`, and all `throws` functions now throw a typed `THPError`, thus removing the need for the client app to cast the error returned.
+
+## Breaking changes from `0.x` to `1.0.0`
 
 There have been significant breaking changes in version `1.x`, mainly due to the adoption of Swift 6.2 and compliance with strict concurrency. Specifically:
 

--- a/Sources/TriforkHealthPlatformSDK/Data/Models/THPError.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Models/THPError.swift
@@ -6,6 +6,15 @@ public typealias THPAuthError = TIMAuthError
 public typealias THPStorageError = TIMStorageError
 public typealias THPEncryptedStorageError = TIMEncryptedStorageError
 
+extension Error {
+    func asTHPError() -> THPError {
+        guard let timError = self as? TIMError else {
+            return .unknown
+        }
+        return timError.asTHPError()
+    }
+}
+
 extension TIMError {
     func asTHPError() -> THPError {
         switch self {
@@ -20,6 +29,7 @@ extension TIMError {
 public enum THPError: Error {
     case auth(THPAuthError)
     case storage(THPStorageError)
+    case unknown
 
     public var errorDescription: String? {
         switch self {
@@ -27,6 +37,8 @@ public enum THPError: Error {
             error.localizedDescription
         case .storage(let error):
             error.localizedDescription
+        case .unknown:
+            "An unexpected error occurred that cannot be identified."
         }
     }
 }

--- a/Sources/TriforkHealthPlatformSDK/Data/Models/THPError.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Models/THPError.swift
@@ -29,6 +29,7 @@ extension TIMError {
 public enum THPError: Error {
     case auth(THPAuthError)
     case storage(THPStorageError)
+    case missingUserId(String)
     case unknown
 
     public var errorDescription: String? {
@@ -37,6 +38,8 @@ public enum THPError: Error {
             error.localizedDescription
         case .storage(let error):
             error.localizedDescription
+        case .missingUserId(let message):
+            message
         case .unknown:
             "An unexpected error occurred that cannot be identified."
         }

--- a/Sources/TriforkHealthPlatformSDK/Data/Protocols/THPAuth.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Protocols/THPAuth.swift
@@ -9,7 +9,7 @@ public protocol THPAuth: Actor {
     ///   - flow: .signin or .signup, depending on which flow you want to run
     ///   - presentingViewController: The view controller which the safari view controller should be presented on.
     /// - Returns: The userId is returned in String format.
-    func performOpenIDConnectFlow(flow: THPAuthenticationFlow, presentingViewController: UIViewController) async throws -> String
+    func performOpenIDConnectFlow(flow: THPAuthenticationFlow, presentingViewController: UIViewController) async throws(THPError) -> String
     
     /// Performs OAuth login or signup with OpenID Connect. The url will be prepared and returned in a NSNotification, for you to present in a custom view.
     ///
@@ -17,7 +17,7 @@ public protocol THPAuth: Actor {
     /// - Parameters:
     ///   - flow: .signin or .signup, depending on which flow you want to run
     /// - Returns: The userId is returned in String format.
-    func performOpenIDConnectFlow(flow: THPAuthenticationFlow) async throws -> String
+    func performOpenIDConnectFlow(flow: THPAuthenticationFlow) async throws(THPError) -> String
     
     /// Handles redirect from the `SFSafariViewController`. The return value determines whether the URL was handled successfully.
     /// - Parameter url: The url that was directed to the app.
@@ -27,18 +27,18 @@ public protocol THPAuth: Actor {
     /// Logs in using biometric login. This can only be done if the user has stored the refresh token with a password after calling `performOpenIDConnectLogin` AND enabled biometric protection for it.
     /// - Parameters:
     ///   - storeNewRefreshToken: `true` if it should store the new refresh token, and `false` if not. Most people will need this as `true`
-    func loginWithBiometricId(storeNewRefreshToken: Bool) async throws -> THPJWT
+    func loginWithBiometricId(storeNewRefreshToken: Bool) async throws(THPError) -> THPJWT
     
     /// Gets the current access token (JWT) from the current session if available.
     /// This will automatically renew the access token if necessary (by using the refresh token)
     /// - Parameter forceRefresh: Force refresh an access token
-    func getAccessToken(forceRefresh: Bool) async throws -> THPJWT
+    func getAccessToken(forceRefresh: Bool) async throws(THPError) -> THPJWT
     
     /// Logs in using password. This can only be done if the user has stored the refresh token with a password after calling `performOpenIDConnectLogin`.
     /// - Parameters:
     ///   - password: The password that was used when the refresh token was stored.
     ///   - storeNewRefreshToken: `true` if it should store the new refresh token, and `false` if not. Most people will need this as `true`
-    func loginWithPassword(password: String, storeNewRefreshToken: Bool) async throws -> THPJWT
+    func loginWithPassword(password: String, storeNewRefreshToken: Bool) async throws(THPError) -> THPJWT
     
     /// Logs out the user of the current session, clearing the auth state with active tokens
     /// - Parameter clearUser: Clears all securely stored data

--- a/Sources/TriforkHealthPlatformSDK/Data/Protocols/THPUserStorage.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Protocols/THPUserStorage.swift
@@ -9,7 +9,7 @@ public protocol THPUserStorage: Actor {
     /// - Parameters:
     ///   - password: The password that was used to store the refresh token.
     ///   - userId: The `userId` for the refresh token.
-    func enableBiometricAccessForRefreshToken(password: String) async throws
+    func enableBiometricAccessForRefreshToken(password: String) async throws(THPError)
     
     /// Checks whether the logged in user has stored a refresh token with biometric protection access.
     func hasBiometricAccessEnabled() async -> Bool
@@ -24,11 +24,11 @@ public protocol THPUserStorage: Actor {
     /// - Parameters:
     ///   - refreshToken: The refresh token.
     ///   - newPassword: The new password that needs a new encryption key.
-    func storeRefreshToken(_ refreshToken: THPJWT, withNewPassword newPassword: String) async throws
+    func storeRefreshToken(_ refreshToken: THPJWT, withNewPassword newPassword: String) async throws(THPError)
     
     /// Gets a stored refresh token for a `userId` and a `password`
     /// - Parameters:
     ///   - userId: The `userId` from the refresh token
     ///   - password: The password that was used to store it.
-    func getStoredRefreshToken(for userId: String, with password: String) async throws -> THPJWT
+    func getStoredRefreshToken(for userId: String, with password: String) async throws(THPError) -> THPJWT
 }

--- a/Sources/TriforkHealthPlatformSDK/Data/Protocols/THPUserStorage.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Protocols/THPUserStorage.swift
@@ -12,10 +12,10 @@ public protocol THPUserStorage: Actor {
     func enableBiometricAccessForRefreshToken(password: String) async throws(THPError)
     
     /// Checks whether the logged in user has stored a refresh token with biometric protection access.
-    func hasBiometricAccessEnabled() async -> Bool
+    func hasBiometricAccessEnabled() async throws(THPError) -> Bool
     
     /// Disables biometric protection access for refresh token.
-    func disableBiometricAccess() async
+    func disableBiometricAccess() async throws(THPError)
     
     ///  Clears all securely stored data for the logged in user
     func clearUser() async

--- a/Sources/TriforkHealthPlatformSDK/Data/Protocols/TIMManager.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Protocols/TIMManager.swift
@@ -5,25 +5,25 @@ import UIKit
 protocol TIMManager: Actor {
     // MARK: - Auth
     
-    func performOpenIDConnectFlow(flow: THPAuthenticationFlow, presentingViewController: UIViewController) async throws -> JWT
-    func performOpenIDConnectFlow(flow: THPAuthenticationFlow) async throws -> JWT
-    @discardableResult 
+    func performOpenIDConnectFlow(flow: THPAuthenticationFlow, presentingViewController: UIViewController) async throws(THPError) -> JWT
+    func performOpenIDConnectFlow(flow: THPAuthenticationFlow) async throws(THPError) -> JWT
+    @discardableResult
     func handleRedirect(url: URL) -> Bool
-    func loginWithBiometricId(userId: String, storeNewRefreshToken: Bool) async throws -> JWT
-    func loginWithPassword(userId: String, password: String, storeNewRefreshToken: Bool) async throws -> JWT
+    func loginWithBiometricId(userId: String, storeNewRefreshToken: Bool) async throws(THPError) -> JWT
+    func loginWithPassword(userId: String, password: String, storeNewRefreshToken: Bool) async throws(THPError) -> JWT
     func clearAllUsers(except userId: String?)
-    func accessToken(forceRefresh: Bool) async throws -> JWT
-    func getStoredRefreshToken(userId: String, password: String) async throws -> JWT
+    func accessToken(forceRefresh: Bool) async throws(THPError) -> JWT
+    func getStoredRefreshToken(userId: String, password: String) async throws(THPError) -> JWT
     var refreshToken: JWT? { get }
     var isLoggedIn: Bool { get }
     
     // MARK: - Storage
     
     var userId: String? { get }
-    func enableBiometricAccessForRefreshToken(password: String, userId: String) async throws -> Void
+    func enableBiometricAccessForRefreshToken(password: String, userId: String) async throws(THPError) -> Void
     func hasBiometricAccessForRefreshToken(userId: String) -> Bool
     func disableBiometricAccessForRefreshToken(userId: String)
-    func storeRefreshToken(_ refreshToken: THPJWT, withNewPassword newPassword: String) async throws -> TIMESKeyCreationResult
+    func storeRefreshToken(_ refreshToken: THPJWT, withNewPassword newPassword: String) async throws(THPError) -> TIMESKeyCreationResult
     
     // MARK: - Mixed (for SDK simplicity)
     

--- a/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Authentication/THPAuthEntity.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Authentication/THPAuthEntity.swift
@@ -11,11 +11,11 @@ public final actor THPAuthEntity: THPAuth {
     public func performOpenIDConnectFlow(
         flow: THPAuthenticationFlow,
         presentingViewController: UIViewController
-    ) async throws -> String {
+    ) async throws(THPError) -> String {
         try await timManager.performOpenIDConnectFlow(flow: flow, presentingViewController: presentingViewController).userId
     }
     
-    public func performOpenIDConnectFlow(flow: THPAuthenticationFlow) async throws -> String {
+    public func performOpenIDConnectFlow(flow: THPAuthenticationFlow) async throws(THPError) -> String {
         try await timManager.performOpenIDConnectFlow(flow: flow).userId
     }
     
@@ -24,7 +24,7 @@ public final actor THPAuthEntity: THPAuth {
         await timManager.handleRedirect(url: url)
     }
     
-    public func loginWithBiometricId(storeNewRefreshToken: Bool) async throws -> THPJWT {
+    public func loginWithBiometricId(storeNewRefreshToken: Bool) async throws(THPError) -> THPJWT {
         guard let userId = await timManager.userId else {
             fatalError("userId is missing!")
         }
@@ -37,7 +37,7 @@ public final actor THPAuthEntity: THPAuth {
         }
     }
     
-    public func loginWithPassword(password: String, storeNewRefreshToken: Bool) async throws -> THPJWT {
+    public func loginWithPassword(password: String, storeNewRefreshToken: Bool) async throws(THPError) -> THPJWT {
         guard let userId = await timManager.userId else {
             fatalError("userId is missing!")
         }
@@ -50,7 +50,7 @@ public final actor THPAuthEntity: THPAuth {
         }
     }
     
-    public func getAccessToken(forceRefresh: Bool = false) async throws -> THPJWT {
+    public func getAccessToken(forceRefresh: Bool = false) async throws(THPError) -> THPJWT {
         let result = try await timManager.accessToken(forceRefresh: forceRefresh)
         if let token = THPJWT(token: result.token) {
             return token

--- a/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Authentication/THPAuthEntity.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Authentication/THPAuthEntity.swift
@@ -33,7 +33,7 @@ public final actor THPAuthEntity: THPAuth {
         if let token = THPJWT(token: result.token) {
             return token
         } else {
-            throw THPError.auth(.failedToValidateIDToken)
+            throw .auth(.failedToValidateIDToken)
         }
     }
     
@@ -46,7 +46,7 @@ public final actor THPAuthEntity: THPAuth {
         if let token = THPJWT(token: result.token) {
             return token
         } else {
-            throw THPError.auth(.failedToValidateIDToken)
+            throw .auth(.failedToValidateIDToken)
         }
     }
     
@@ -55,7 +55,7 @@ public final actor THPAuthEntity: THPAuth {
         if let token = THPJWT(token: result.token) {
             return token
         } else {
-            throw THPError.auth(.failedToValidateIDToken)
+            throw .auth(.failedToValidateIDToken)
         }
     }
 

--- a/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Authentication/THPAuthEntity.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Authentication/THPAuthEntity.swift
@@ -26,7 +26,7 @@ public final actor THPAuthEntity: THPAuth {
     
     public func loginWithBiometricId(storeNewRefreshToken: Bool) async throws(THPError) -> THPJWT {
         guard let userId = await timManager.userId else {
-            fatalError("userId is missing!")
+            throw .missingUserId("You must have a stored user to login with biometrics")
         }
         
         let result = try await timManager.loginWithBiometricId(userId: userId, storeNewRefreshToken: storeNewRefreshToken)
@@ -39,7 +39,7 @@ public final actor THPAuthEntity: THPAuth {
     
     public func loginWithPassword(password: String, storeNewRefreshToken: Bool) async throws(THPError) -> THPJWT {
         guard let userId = await timManager.userId else {
-            fatalError("userId is missing!")
+            throw .missingUserId("You must have a stored user to login with password")
         }
         
         let result = try await timManager.loginWithPassword(userId: userId, password: password, storeNewRefreshToken: storeNewRefreshToken)

--- a/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Storage/THPUserStorageEntity.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Storage/THPUserStorageEntity.swift
@@ -14,7 +14,7 @@ public final actor THPUserStorageEntity: THPUserStorage {
         }
     }
     
-    public func enableBiometricAccessForRefreshToken(password: String) async throws {
+    public func enableBiometricAccessForRefreshToken(password: String) async throws(THPError) {
         guard let userId = await timManager.userId else {
             fatalError("You must have a logged in user to enable Biometrics")
         }
@@ -39,11 +39,11 @@ public final actor THPUserStorageEntity: THPUserStorage {
         await timManager.clearAllUsers(except: nil)
     }
     
-    public func storeRefreshToken(_ refreshToken: THPJWT, withNewPassword newPassword: String) async throws {
+    public func storeRefreshToken(_ refreshToken: THPJWT, withNewPassword newPassword: String) async throws(THPError) {
         _ = try await timManager.storeRefreshToken(refreshToken, withNewPassword: newPassword)
     }
     
-    public func getStoredRefreshToken(for userId: String, with password: String) async throws -> THPJWT {
+    public func getStoredRefreshToken(for userId: String, with password: String) async throws(THPError) -> THPJWT {
         let jwt = try await timManager.getStoredRefreshToken(userId: userId, password: password)
         if let token = THPJWT(token: jwt.token) {
             return token

--- a/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Storage/THPUserStorageEntity.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Storage/THPUserStorageEntity.swift
@@ -48,7 +48,7 @@ public final actor THPUserStorageEntity: THPUserStorage {
         if let token = THPJWT(token: jwt.token) {
             return token
         } else {
-            throw THPError.auth(.failedToGetRefreshToken)
+            throw .auth(.failedToGetRefreshToken)
         }
     }
 }

--- a/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Storage/THPUserStorageEntity.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/Storage/THPUserStorageEntity.swift
@@ -1,4 +1,3 @@
-import Combine
 import Foundation
 
 public final actor THPUserStorageEntity: THPUserStorage {
@@ -16,21 +15,21 @@ public final actor THPUserStorageEntity: THPUserStorage {
     
     public func enableBiometricAccessForRefreshToken(password: String) async throws(THPError) {
         guard let userId = await timManager.userId else {
-            fatalError("You must have a logged in user to enable Biometrics")
+            throw .missingUserId("You must have a logged in user to enable Biometrics")
         }
         try await timManager.enableBiometricAccessForRefreshToken(password: password, userId: userId)
     }
     
-    public func hasBiometricAccessEnabled() async -> Bool {
+    public func hasBiometricAccessEnabled() async throws(THPError) -> Bool {
         guard let userId = await timManager.userId else {
-            fatalError("You must have a logged in user to call \(#function)")
+            throw .missingUserId("You must have a logged in user to call \(#function)")
         }
         return await timManager.hasBiometricAccessForRefreshToken(userId: userId)
     }
     
-    public func disableBiometricAccess() async {
+    public func disableBiometricAccess() async throws(THPError) {
         guard let userId = await timManager.userId else {
-            fatalError("You must have a logged in user to disable Biometrics")
+            throw .missingUserId("You must have a logged in user to disable Biometrics")
         }
         await timManager.disableBiometricAccessForRefreshToken(userId: userId)
     }

--- a/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/TIMManagerEntity.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/TIMManagerEntity.swift
@@ -27,38 +27,62 @@ public final actor TIMManagerEntity: TIMManager {
         TIM.auth.isLoggedIn
     }
     
-    func performOpenIDConnectFlow(flow: THPAuthenticationFlow, presentingViewController: UIViewController) async throws -> JWT {
+    func performOpenIDConnectFlow(flow: THPAuthenticationFlow, presentingViewController: UIViewController) async throws(THPError) -> JWT {
         configureTIM(for: flow)
-        return try await TIM.auth.performOpenIDConnectLogin(presentingViewController: presentingViewController).value
+        do {
+            return try await TIM.auth.performOpenIDConnectLogin(presentingViewController: presentingViewController).value
+        } catch {
+            throw error.asTHPError()
+        }
     }
     
-    func performOpenIDConnectFlow(flow: THPAuthenticationFlow) async throws -> JWT {
+    func performOpenIDConnectFlow(flow: THPAuthenticationFlow) async throws(THPError) -> JWT {
         configureTIM(for: flow)
-        return try await TIM.auth.performOpenIDConnectLogin().value
+        do {
+            return try await TIM.auth.performOpenIDConnectLogin().value
+        } catch {
+            throw error.asTHPError()
+        }
     }
     
     func handleRedirect(url: URL) -> Bool {
         TIM.auth.handleRedirect(url: url)
     }
     
-    func loginWithBiometricId(userId: String, storeNewRefreshToken: Bool) async throws -> JWT {
-        try await TIM.auth.loginWithBiometricId(userId: userId, storeNewRefreshToken: storeNewRefreshToken, willBeginNetworkRequests: nil).value
+    func loginWithBiometricId(userId: String, storeNewRefreshToken: Bool) async throws(THPError) -> JWT {
+        do {
+            return try await TIM.auth.loginWithBiometricId(userId: userId, storeNewRefreshToken: storeNewRefreshToken, willBeginNetworkRequests: nil).value
+        } catch {
+            throw error.asTHPError()
+        }
     }
     
-    func loginWithPassword(userId: String, password: String, storeNewRefreshToken: Bool) async throws -> JWT {
-        try await TIM.auth.loginWithPassword(userId: userId, password: password, storeNewRefreshToken: storeNewRefreshToken).value
+    func loginWithPassword(userId: String, password: String, storeNewRefreshToken: Bool) async throws(THPError) -> JWT {
+        do {
+            return try await TIM.auth.loginWithPassword(userId: userId, password: password, storeNewRefreshToken: storeNewRefreshToken).value
+        } catch {
+            throw error.asTHPError()
+        }
     }
     
     func clearAllUsers(except userId: String?) {
         TIM.storage.clearAllUsers(exceptUserId: userId)
     }
     
-    func accessToken(forceRefresh: Bool) async throws -> JWT {
-        try await TIM.auth.accessToken(forceRefresh: forceRefresh).value
+    func accessToken(forceRefresh: Bool) async throws(THPError) -> JWT {
+        do {
+            return try await TIM.auth.accessToken(forceRefresh: forceRefresh).value
+        } catch {
+            throw error.asTHPError()
+        }
     }
     
-    func getStoredRefreshToken(userId: String, password: String) async throws -> JWT {
-        try await TIM.storage.getStoredRefreshToken(userId: userId, password: password).value
+    func getStoredRefreshToken(userId: String, password: String) async throws(THPError) -> JWT {
+        do {
+            return try await TIM.storage.getStoredRefreshToken(userId: userId, password: password).value
+        } catch {
+            throw error.asTHPError()
+        }
     }
     
     // MARK: - Storage
@@ -67,8 +91,12 @@ public final actor TIMManagerEntity: TIMManager {
         TIM.storage.availableUserIds.first
     }
     
-    func enableBiometricAccessForRefreshToken(password: String, userId: String) async throws {
-        try await TIM.storage.enableBiometricAccessForRefreshToken(password: password, userId: userId).value
+    func enableBiometricAccessForRefreshToken(password: String, userId: String) async throws(THPError) {
+        do {
+            return try await TIM.storage.enableBiometricAccessForRefreshToken(password: password, userId: userId).value
+        } catch {
+            throw error.asTHPError()
+        }
     }
     
     func hasBiometricAccessForRefreshToken(userId: String) -> Bool {
@@ -79,11 +107,15 @@ public final actor TIMManagerEntity: TIMManager {
         TIM.storage.disableBiometricAccessForRefreshToken(userId: userId)
     }
     
-    func storeRefreshToken(_ refreshToken: THPJWT, withNewPassword newPassword: String) async throws -> TIMESKeyCreationResult {
+    func storeRefreshToken(_ refreshToken: THPJWT, withNewPassword newPassword: String) async throws(THPError) -> TIMESKeyCreationResult {
         guard let timToken = JWT(token: refreshToken.token) else {
             throw THPError.auth(THPAuthError.failedToGetRefreshToken)
         }
-        return try await TIM.storage.storeRefreshToken(timToken, withNewPassword: newPassword).value
+        do {
+            return try await TIM.storage.storeRefreshToken(timToken, withNewPassword: newPassword).value
+        } catch {
+            throw error.asTHPError()
+        }
     }
     
     // MARK: - Mixed (for SDK simplicity)

--- a/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/TIMManagerEntity.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/TIMManagerEntity.swift
@@ -109,7 +109,7 @@ public final actor TIMManagerEntity: TIMManager {
     
     func storeRefreshToken(_ refreshToken: THPJWT, withNewPassword newPassword: String) async throws(THPError) -> TIMESKeyCreationResult {
         guard let timToken = JWT(token: refreshToken.token) else {
-            throw THPError.auth(THPAuthError.failedToGetRefreshToken)
+            throw .auth(THPAuthError.failedToGetRefreshToken)
         }
         do {
             return try await TIM.storage.storeRefreshToken(timToken, withNewPassword: newPassword).value


### PR DESCRIPTION
## Summary

In this PR we refactor the existing throwing functions to throw typed errors. That is, instead of throwing a generic instance of `Error`, now throwing functions do throw the specific type `THPError`.

## Changes

- Added further cases to `THPError`.
- Implemented mapping from `Error` to `THPError`, passing through `TIMError`.
- Refactored all throwing functions to throw an instance of `THPError`.
- Refactored some functions causing a `fatalError()` when `userId` is missing to throw a `THPError.missingUserId` instead.
- Updated documentation in README.md file.