### PR TITLE
[Refactor] Add "additionalParameters" to THPConfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ let config = THPConfiguration(
     clientId: "<clientId>",
     redirectUrl: URL(string:"<urlScheme>:/")!,
     baseAuthURL: URL(string: "<Base Auth URL>")!,
-    loginFlowKey: "<Client Login Flow Key>"
+    loginFlowKey: "<Client Login Flow Key>",
+    additionalParameters: ["configurationKey": "configurationValue"]
 )
 
 let thp = await THP(configuration: config)
@@ -68,7 +69,8 @@ let config = THPConfiguration(
     clientId: "<clientId>",
     redirectUrl: URL(string:"<urlScheme>:/")!,
     baseAuthURL: URL(string: "<Base Auth URL>")!,
-    loginFlowKey: "<Client Login Flow Key>"
+    loginFlowKey: "<Client Login Flow Key>",
+    additionalParameters: ["configurationKey": "configurationValue"]
 )
 
 await THP.shared.configure(config)

--- a/Sources/TriforkHealthPlatformSDK/Core/Extensions/Locale+ApplicationLocale.swift
+++ b/Sources/TriforkHealthPlatformSDK/Core/Extensions/Locale+ApplicationLocale.swift
@@ -1,7 +1,0 @@
-import Foundation
-
-extension Locale {
-    public static var applicationLocale: Locale {
-        Bundle.main.preferredLocalizations.first.flatMap { Locale(identifier: $0) } ?? Locale.current
-    }
-}

--- a/Sources/TriforkHealthPlatformSDK/Data/Models/THPConfiguration.swift
+++ b/Sources/TriforkHealthPlatformSDK/Data/Models/THPConfiguration.swift
@@ -8,7 +8,8 @@ public struct THPConfiguration: Sendable {
     public let clientId: String
     public let redirectUrl: String
     public let loginFlowKey: String
-    
+    public let additionalParameters: [String: String]
+
     /// Default constructor
     /// - Parameters:
     ///   - scopes: Scopes, e.g. `["scope"]`
@@ -17,13 +18,15 @@ public struct THPConfiguration: Sendable {
     ///   - redirectUrl: Redirect URL, e.g. `"my-app:/"`
     ///   - baseAuthURL: Base base URL to authenticate, e.g. https://trifork.com
     ///   - loginFlowKey: The client app key to identify the login flow source, e.g. `"client-flow"`
+    ///   - additionalParameters: Additional configuration parameters, such as the prompt or the locale for the UI.
     public init(
         scopes: [String],
         realm: String,
         clientId: String,
         redirectUrl: String,
         baseAuthURL: URL,
-        loginFlowKey: String
+        loginFlowKey: String,
+        additionalParameters: [String: String]
     ) {
         self.scopes = scopes
         self.realm = realm
@@ -31,5 +34,6 @@ public struct THPConfiguration: Sendable {
         self.redirectUrl = redirectUrl
         self.baseAuthURL = baseAuthURL
         self.loginFlowKey = loginFlowKey
+        self.additionalParameters = additionalParameters
     }
 }

--- a/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/TIMManagerEntity.swift
+++ b/Sources/TriforkHealthPlatformSDK/Implementations/TIMWrappers/TIMManagerEntity.swift
@@ -144,11 +144,7 @@ extension TIMManagerEntity{
                 redirectUri: URL(string: thpConfiguration.redirectUrl)!,
                 scopes: thpConfiguration.scopes,
                 encryptionMethod: .aesGcm,
-                additionalParameters: [
-                    "ui_locales": Locale.applicationLocale.identifier.split(separator: "-")[0].description,
-                    "prompt": "login",
-                    thpConfiguration.loginFlowKey: flow.rawValue
-                ]
+                additionalParameters: thpConfiguration.additionalParameters.merging([thpConfiguration.loginFlowKey: flow.rawValue], uniquingKeysWith: { $1 })
             ),
             allowReconfigure: true,
             customOIDExternalUserAgent: customOIDExternalUserAgent


### PR DESCRIPTION
## Summary

In this PR we update the `THPConfiguration` to add an `additionalParameters` Dictionary, and then replace the default `additionalParameters` passed to `TIMConfiguration`.

## Motivation

When switching to Keycloak login in Compassana, some of the default parameters passed to the `additionalParameters` in `TIMConfiguration` should not be there. Instead of updating this library every time there is such a change, we should make it as agnostic.

## Changes

* Added `additionalParameters` dictionary parameter to `THPConfiguration`.
* Updated initialization of `TIMConfiguration` to account for the values in the new parameter.
* Removed localization passed to `TIMConfiguration`: now it needs to be provided by the client.
* Updated documentation.